### PR TITLE
Add privacy manifest 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,9 @@ let package = Package(
             name: "PersistableTimer",
             dependencies: [
                 "PersistableTimerCore"
-            ]
+            ],
+            path: "Sources/PersistableTimer",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "PersistableTimerCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,6 @@ let package = Package(
             dependencies: [
                 "PersistableTimerCore"
             ],
-            path: "Sources/PersistableTimer",
             resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(

--- a/Sources/PersistableTimer/PrivacyInfo.xcprivacy
+++ b/Sources/PersistableTimer/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
To comply with Apple's new privacy policies every third-party SDK should include a Privacy manifest in case if they access APIs which potentially can be used for fingerprinting.
So, I believe it falls under the following content, I add the PrivacyInfo.xcprivacy

- [C56D.1 ](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)