### PR TITLE
Implement Time Adjustment Functions: addRemainingTime / addElapsedTime

### DIFF
--- a/Examples/TimerTest/TimerTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/TimerTest/TimerTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "54b5944423804ba96689c1095d3c165711f7de78f9a25eb4b7f02125ca922c1b",
   "pins" : [
     {
       "identity" : "editvalueview",
@@ -28,30 +29,21 @@
       }
     },
     {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras.git",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
       "identity" : "swift-magic-mirror",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-magic-mirror.git",
       "state" : {
         "revision" : "390e248dd6727e17aeb3949c12bb83e6eac876d1",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "06b5cdc432e93b60e3bdf53aff2857c6b312991a",
-        "version" : "600.0.0-prerelease-2024-07-30"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing",
-      "state" : {
-        "revision" : "69d59cfc76e5daf498ca61f5af409f594768eef9",
-        "version" : "0.10.0"
       }
     },
     {
@@ -82,5 +74,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Examples/TimerTest/TimerTest/StopwatchView.swift
+++ b/Examples/TimerTest/TimerTest/StopwatchView.swift
@@ -42,6 +42,16 @@ final class StopwatchModel {
         }
     }
 
+    /// Calls addElapsedTime(5) to increase the stopwatch's elapsed time by 5 seconds.
+    func addExtraElapsedTime() async {
+        do {
+            let container = try await persistableTimer.addElapsedTime(5)
+            self.timerState = container.elapsedTimeAndStatus()
+        } catch {
+            print("Error adding elapsed time: \(error)")
+        }
+    }
+
     func synchronize() async {
         timerState = try? persistableTimer.getTimerData()?.elapsedTimeAndStatus()
     }
@@ -55,7 +65,7 @@ struct StopwatchView: View {
     let stopwatchModel: StopwatchModel
 
     public var body: some View {
-        VStack {
+        VStack(spacing: 20) {
             Text(timerState: stopwatchModel.timerState)
                 .font(.title)
 
@@ -65,6 +75,11 @@ struct StopwatchView: View {
                 }
             } label: {
                 Text(stopwatchModel.buttonTitle)
+            }
+            Button("Add 5 sec") {
+                Task {
+                    await stopwatchModel.addExtraElapsedTime()
+                }
             }
         }
         .task {

--- a/Examples/TimerTest/TimerTest/TimerView.swift
+++ b/Examples/TimerTest/TimerTest/TimerView.swift
@@ -53,6 +53,16 @@ final class TimerModel {
         }
     }
 
+    /// Calls addRemainingTime(5) to extend the timer's remaining duration by 5 seconds.
+    func addExtraTime() async {
+        do {
+            let container = try await persistableTimer.addRemainingTime(5)
+            self.timerState = container.elapsedTimeAndStatus()
+        } catch {
+            print("Error adding remaining time: \(error)")
+        }
+    }
+
     func synchronize() async {
         timerState = try? persistableTimer.getTimerData()?.elapsedTimeAndStatus()
     }
@@ -66,7 +76,7 @@ struct TimerView: View {
     @Bindable var timerModel: TimerModel
 
     var body: some View {
-        VStack {
+        VStack(spacing: 20) {
             if let timerState = timerModel.timerState {
                 Text(timerState: timerState)
                     .font(.title)
@@ -83,6 +93,14 @@ struct TimerView: View {
                 }
             } label: {
                 Text(timerModel.buttonTitle)
+            }
+            // 「Add 5 sec」ボタンは、タイマータイプ（.timer）の場合のみ表示
+            if let timerState = timerModel.timerState, case .timer = timerState.type {
+                Button("Add 5 sec") {
+                    Task {
+                        await timerModel.addExtraTime()
+                    }
+                }
             }
         }
         .task {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c61cd60b15cfbb30ea1026543fd876576ac60fa432596f8a34ee205b90fe3233",
+  "originHash" : "0395560d25e31e5d0c5ea880878f181e6595013c7c017b9915364edf3bf79c85",
   "pins" : [
     {
       "identity" : "swift-async-algorithms",
@@ -26,24 +26,6 @@
       "state" : {
         "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
         "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "82a453c2dfa335c7e778695762438dfe72b328d2",
-        "version" : "600.0.0-prerelease-2024-07-24"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing",
-      "state" : {
-        "revision" : "69d59cfc76e5daf498ca61f5af409f594768eef9",
-        "version" : "0.10.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-testing", exact: "0.10.0"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", exact: "1.3.1")
     ],
     targets: [
@@ -58,7 +57,6 @@ let package = Package(
             name: "PersistableTimerCoreTests",
             dependencies: [
                 "PersistableTimerCore",
-                .product(name: "Testing", package: "swift-testing")
             ]
         ),
     ]


### PR DESCRIPTION
## Overview

This PR introduces new functions to allow manual time adjustments for timers and stopwatches.

### New Functions:

- **`addRemainingTime(extraTime:)`**  
  - Extends the remaining duration of a countdown timer by the specified number of seconds.

- **`addElapsedTime(extraTime:)`**  
  - Increases the elapsed time of a stopwatch by adjusting the start time backward.

## Motivation

These functions provide users with the flexibility to manually correct or adjust the timer and stopwatch durations as needed.

## Changes

- Implemented `addRemainingTime(extraTime:)` and `addElapsedTime(extraTime:)` in `PersistableTimerCore`.
- Added wrapper functions in `PersistableTimer` to expose these features.
